### PR TITLE
fix js when selecting 'GitLab' provider

### DIFF
--- a/app/controllers/redmine_oauth_controller.rb
+++ b/app/controllers/redmine_oauth_controller.rb
@@ -40,7 +40,7 @@ class RedmineOauthController < AccountController
       redirect_to oauth_client.auth_code.authorize_url(
         redirect_uri: oauth_callback_url,
         state: oauth_csrf_token,
-        scope: 'read_user api read_api openid profile email'
+        scope: 'read_user'
       )
     when 'Okta'
       redirect_to oauth_client.auth_code.authorize_url(

--- a/app/views/settings/_oauth_settings.html.erb
+++ b/app/views/settings/_oauth_settings.html.erb
@@ -74,7 +74,7 @@
       <%= text_field_tag 'settings[client_secret]', @settings[:client_secret], size: 40 %>
       <em class="info"><%= l(:oauth_client_secret_info) %></em>
     </p>
-    <p>
+    <p id="oauth_options_tenant">
       <label><%= l(:oauth_tenant_id) %></label>
       <%= text_field_tag 'settings[tenant_id]', @settings[:tenant_id], size: 40 %>
       <em class="info"><%= l(:oauth_tenant_id_info) %></em>

--- a/assets/javascripts/redmine_oauth.js
+++ b/assets/javascripts/redmine_oauth.js
@@ -59,11 +59,17 @@ function oauth_settings_visibility()
             break;
         case 'Azure AD':
             div_oauth_options.show();
+            div_oauth_options.find('#oauth_options_tenant').show();
             tenant_id.val("");
             break;
         case 'Okta':
             div_oauth_options.show();
+            div_oauth_options.find('#oauth_options_tenant').show();
             tenant_id.val("default");
+            break;
+        case 'GitLab':
+            div_oauth_options.show();
+            div_oauth_options.find('#oauth_options_tenant').hide();
             break;
         default:
             break;


### PR DESCRIPTION
There is a tiny Bug  when changing the select dropdown to GitLab. If client_id, client_secret, etc fields have been hidden before, they stay invisible.

I am also hiding tenant_id for GitLab since it isn't used.

Thanks for the great plugin!