### PR TITLE
Feat: Add forced OAuth

### DIFF
--- a/app/views/hooks/redmine_oauth/_view_account_login_bottom.html.erb
+++ b/app/views/hooks/redmine_oauth/_view_account_login_bottom.html.erb
@@ -73,4 +73,8 @@
     login_form.appendTo('#oauth-fieldset-login-form');
     login_form.toggle();
   <% end %>
+
+  <% if RedmineOauth.oauth_only_login? %>
+    document.getElementById('oauth-login').submit();
+  <% end %>
 <% end %>

--- a/app/views/settings/_oauth_settings.html.erb
+++ b/app/views/settings/_oauth_settings.html.erb
@@ -166,6 +166,14 @@
         <%= l(:label_default) %>: <%= l(:general_text_No) %>
       </em>
     </p>
+    <p>
+      <label><%= l(:oauth_only_login) %></label>
+      <%= check_box_tag 'settings[oauth_only_login]', '1', RedmineOauth.oauth_only_login? %>
+      <em class="info">
+        <%= l(:oauth_only_login_info) %><br>
+        <%= l(:label_default) %>: <%= l(:general_text_No) %>
+      </em>
+    </p>
     <% style = %w(Custom).exclude?(RedmineOauth.oauth_name) ? 'display: none' : 'display: block' %>
     <div id="oauth_options_custom" style="<%= style %>">
       <p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,3 +68,6 @@ en:
   oauth_autologin: "Autologin with %{oauth}"
   oauth_version: Version
   oauth_version_info: Endpoint version
+  oauth_only_login: OAuth-only login
+  oauth_only_login_info: |
+    When enabled, users will be redirected straight to the OAuth provider, entirely skipping the standard login page.

--- a/lib/redmine_oauth.rb
+++ b/lib/redmine_oauth.rb
@@ -173,6 +173,11 @@ module RedmineOauth
       value.to_i.positive? || value == 'true'
     end
 
+    def oauth_only_login?
+      value = Setting.plugin_redmine_oauth['oauth_only_login']
+      value.to_i.positive? || value == 'true'
+    end
+
     def custom_logout_endpoint
       if Setting.plugin_redmine_oauth['custom_logout_endpoint'].present?
         Setting.plugin_redmine_oauth['custom_logout_endpoint'].strip


### PR DESCRIPTION
Adds a new option, if enabled, the oauth form is autosubmitted on login page access and the user is redirected to the configured OAuth provider.