### PR TITLE
Fix URL concatenation for Keycloak

### DIFF
--- a/lib/redmine_oauth/oauth_client.rb
+++ b/lib/redmine_oauth/oauth_client.rb
@@ -64,8 +64,8 @@ module RedmineOauth
             RedmineOauth.client_id,
             Redmine::Ciphering.decrypt_text(RedmineOauth.client_secret),
             site: site,
-            authorize_url: "/realms/#{RedmineOauth.tenant_id}/protocol/openid-connect/auth",
-            token_url: "/realms/#{RedmineOauth.tenant_id}/protocol/openid-connect/token"
+            authorize_url: "realms/#{RedmineOauth.tenant_id}/protocol/openid-connect/auth",
+            token_url: "realms/#{RedmineOauth.tenant_id}/protocol/openid-connect/token"
           )
         when 'Okta'
           OAuth2::Client.new(

--- a/test/functional/redmine_oauth_controller_test.rb
+++ b/test/functional/redmine_oauth_controller_test.rb
@@ -27,10 +27,20 @@ class RedmineOauthControllerTest < ActionDispatch::IntegrationTest
   fixtures :users
 
   def test_oauth
-    Setting.plugin_redmine_oauth[:oauth_name] = ''
+    Setting.plugin_redmine_oauth['oauth_name'] = ''
     get '/oauth'
     assert_redirected_to signin_path
     assert_equal l(:oauth_invalid_provider), flash[:error]
+  end
+
+  def test_oauth_url_concatenation_for_keycloak
+    Setting.plugin_redmine_oauth['oauth_name'] = 'Keycloak'
+    Setting.plugin_redmine_oauth['site'] = 'https://example.com/sso'
+    Setting.plugin_redmine_oauth['client_id'] = 'example-client'
+    Setting.plugin_redmine_oauth['client_secret'] = 'florp-burp-durk'
+    Setting.plugin_redmine_oauth['tenant_id'] = 'redmine'
+    get '/oauth'
+    assert_redirected_to(%r{^https://example\.com/sso/realms/redmine/protocol/})
   end
 
   def test_oauth_callback_csrf


### PR DESCRIPTION
This fixes an issue (#89) with how URLs are concatenated in OAuth2/Faraday

This lead to not being able to specify an URL prefix in the `site` configuration attribute, ala `https://example.com/auth` which is something that seems to be common on keycloak instances.

This commit specifically fixes the keycloak config by removing the leading slash. I left everything else  as I am not sure if this would be the correct thing to do for other providers.

(Specifically, the "custom" provider does not prefix URLs with a slash, so this should be fine)