### PR TITLE
Fix enable group roles label

### DIFF
--- a/app/views/settings/_oauth_settings.html.erb
+++ b/app/views/settings/_oauth_settings.html.erb
@@ -143,7 +143,7 @@
       <em class="info"><%= l(:oauth_validate_user_roles_info) %></em>
     </p>
     <p>
-      <label><%= l(:oauth_oauth_enable_group_roles) %></label>
+      <label><%= l(:oauth_enable_group_roles) %></label>
       <%= check_box_tag 'settings[enable_group_roles]', '1', RedmineOauth.enable_group_roles? %>
       <em class="info">
         <%= l(:oauth_enable_group_roles_info) %><br>


### PR DESCRIPTION
I noticed that the label in the settings dialog was showing as a missing translation. Looking at the label in the view this seems like a copy/paste error.