### PR TITLE
Add domain-based OAuth self-registration (auto-activate allowlist)

### DIFF
--- a/app/controllers/redmine_oauth_controller.rb
+++ b/app/controllers/redmine_oauth_controller.rb
@@ -333,6 +333,16 @@ class RedmineOauthController < AccountController
         register_automatically(user) do
           onthefly_creation_failed user
         end
+      when 4
+        if RedmineOauth.self_registration_domain_auto_activate?(email)
+          register_automatically(user) do
+            onthefly_creation_failed user
+          end
+        else
+          register_manually_by_administrator(user) do
+            onthefly_creation_failed user
+          end
+        end
       else
         register_manually_by_administrator(user) do
           onthefly_creation_failed user

--- a/app/models/oauth_provider.rb
+++ b/app/models/oauth_provider.rb
@@ -23,7 +23,7 @@ class OauthProvider < ApplicationRecord
 
   validates :oauth_name, presence: true
   validates :site, format: { without: /\.ru\b/ }, length: { maximum: 256 }
-  validates :client_id, presence: true, length: { maximum: 255 }
+  validates :client_id, presence: true, length: { maximum: 256 }
   validates :client_secret, presence: true, length: { maximum: 128 } # Must be longer due to an optional cyphering
   validates :tenant_id, length: { maximum: 40 }
   validates :custom_name, presence: true, uniqueness: true, length: { maximum: 30 }

--- a/app/models/oauth_provider.rb
+++ b/app/models/oauth_provider.rb
@@ -23,7 +23,7 @@ class OauthProvider < ApplicationRecord
 
   validates :oauth_name, presence: true
   validates :site, format: { without: /\.ru\b/ }, length: { maximum: 256 }
-  validates :client_id, presence: true, length: { maximum: 80 }
+  validates :client_id, presence: true, length: { maximum: 255 }
   validates :client_secret, presence: true, length: { maximum: 128 } # Must be longer due to an optional cyphering
   validates :tenant_id, length: { maximum: 40 }
   validates :custom_name, presence: true, uniqueness: true, length: { maximum: 30 }

--- a/app/views/settings/_oauth_settings.html.erb
+++ b/app/views/settings/_oauth_settings.html.erb
@@ -27,10 +27,21 @@
       [l(:label_disabled), '0'],
       [l(:label_registration_activation_by_email), '1'],
       [l(:label_registration_manual_activation), '2'],
-      [l(:label_registration_automatic_activation), '3']
+      [l(:label_registration_automatic_activation), '3'],
+      [l(:oauth_self_registration_by_domain), '4']
     ], RedmineOauth.self_registration), onchange: 'oauth_self_registration_changed();' %>
   <em class="info"><%= l(:label_default)%>: <%= l(:label_disabled) %></em>
 </p>
+<% domains_visible = RedmineOauth.self_registration == 4 %>
+<div id="oauth_self_registration_domains_setting" style="<%= domains_visible ? '' : 'display: none;' %>">
+  <p>
+    <label><%= l(:oauth_self_registration_domains) %></label>
+    <%= text_area_tag 'settings[self_registration_domains]',
+                      Setting.plugin_redmine_oauth['self_registration_domains'],
+                      rows: 3, cols: 60 %>
+    <em class="info"><%= l(:oauth_self_registration_domains_info) %></em>
+  </p>
+</div>
 <p>
   <label><%= l(:oauth_hide_login_form) %></label>
   <%= check_box_tag 'settings[hide_login_form]', '1', RedmineOauth.hide_login_form? %>

--- a/assets/javascripts/redmine_oauth.js
+++ b/assets/javascripts/redmine_oauth.js
@@ -153,3 +153,23 @@ function oauth_toggle_fieldset(el)
     fieldset.classList.toggle('oauth_collapsed');
     $('div#login-form').toggle();
 }
+
+function oauth_self_registration_changed() {
+    let sel = $("select[name='settings[self_registration]']");
+    if (!sel.length) {
+        return;
+    }
+    let domainsBlock = $("div#oauth_self_registration_domains_setting");
+    if (!domainsBlock.length) {
+        return;
+    }
+    if (sel.val() === '4') {
+        domainsBlock.show();
+    } else {
+        domainsBlock.hide();
+    }
+}
+
+$(function () {
+    oauth_self_registration_changed();
+});

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,11 @@ en:
   oauth_custom_scope_info: "OAuth scope (default: 'openid profile email')."
   oauth_custom_uid_field_info: "UID field (default: preferred_username)."
   oauth_custom_email_field_info: "Email field (default: email)."
+  oauth_self_registration_by_domain: Automatic activation for listed email domains only
+  oauth_self_registration_domains: Allowed domains (comma-separated)
+  oauth_self_registration_domains_info: |
+    Users whose email address is at one of these domains (or a subdomain) are activated automatically.
+    All other new users are created pending administrator approval. Example: example.com, partner.org
   oauth_hide_login_form: Hide login form
   oauth_update_login: Update login
   oauth_update_login_info: Update the user's login after a successful login.

--- a/db/migrate/20260204085156_create_oauth_providers.rb
+++ b/db/migrate/20260204085156_create_oauth_providers.rb
@@ -22,8 +22,8 @@ class CreateOauthProviders < ActiveRecord::Migration[7.2]
   def up
     create_table :oauth_providers do |t|
       t.string :oauth_name, null: false, default: 'none', limit: 30
-      t.string :site, null: false, limit: 40
-      t.string :client_id, null: false, limit: 60
+      t.string :site, null: false, limit: 256
+      t.string :client_id, null: false, limit: 255
       t.string :client_secret, null: false, limit: 128
       t.string :tenant_id, null: false, limit: 40
       t.string :custom_name, null: false, limit: 30

--- a/db/migrate/20260204085156_create_oauth_providers.rb
+++ b/db/migrate/20260204085156_create_oauth_providers.rb
@@ -22,8 +22,8 @@ class CreateOauthProviders < ActiveRecord::Migration[7.2]
   def up
     create_table :oauth_providers do |t|
       t.string :oauth_name, null: false, default: 'none', limit: 30
-      t.string :site, null: false, limit: 256
-      t.string :client_id, null: false, limit: 255
+      t.string :site, null: false, limit: 40
+      t.string :client_id, null: false, limit: 60
       t.string :client_secret, null: false, limit: 128
       t.string :tenant_id, null: false, limit: 40
       t.string :custom_name, null: false, limit: 30

--- a/db/migrate/20260325120001_oauth_provider_client_id_length.rb
+++ b/db/migrate/20260325120001_oauth_provider_client_id_length.rb
@@ -3,13 +3,17 @@
 # Redmine plugin OAuth
 #
 # Widen client_id: Google and other providers use IDs longer than varchar(60).
+# Widen site as well to keep both URL-related fields consistent.
 
+# OauthProviders DB migration
 class OauthProviderClientIdLength < ActiveRecord::Migration[7.2]
   def up
-    change_column :oauth_providers, :client_id, :string, null: false, limit: 255
+    change_column :oauth_providers, :site, :string, null: true, limit: 256
+    change_column :oauth_providers, :client_id, :string, null: false, limit: 256
   end
 
   def down
-    change_column :oauth_providers, :client_id, :string, null: false, limit: 60
+    change_column :oauth_providers, :site, :string, null: true, limit: 256
+    change_column :oauth_providers, :client_id, :string, null: false, limit: 80
   end
 end

--- a/db/migrate/20260325120001_oauth_provider_client_id_length.rb
+++ b/db/migrate/20260325120001_oauth_provider_client_id_length.rb
@@ -13,7 +13,7 @@ class OauthProviderClientIdLength < ActiveRecord::Migration[7.2]
   end
 
   def down
-    change_column :oauth_providers, :site, :string, null: true, limit: 256
+    change_column :oauth_providers, :site, :string, null: true, limit: 40
     change_column :oauth_providers, :client_id, :string, null: false, limit: 80
   end
 end

--- a/db/migrate/20260325120001_oauth_provider_client_id_length.rb
+++ b/db/migrate/20260325120001_oauth_provider_client_id_length.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Redmine plugin OAuth
+#
+# Widen client_id: Google and other providers use IDs longer than varchar(60).
+
+class OauthProviderClientIdLength < ActiveRecord::Migration[7.2]
+  def up
+    change_column :oauth_providers, :client_id, :string, null: false, limit: 255
+  end
+
+  def down
+    change_column :oauth_providers, :client_id, :string, null: false, limit: 60
+  end
+end

--- a/init.rb
+++ b/init.rb
@@ -33,6 +33,7 @@ Redmine::Plugin.register :redmine_oauth do
   settings default: {
     hide_login_form: '0',
     self_registration: '0',
+    self_registration_domains: '',
     update_login: '0',
     oauth_logout: '0',
     oauth_login: '0',

--- a/lib/redmine_oauth.rb
+++ b/lib/redmine_oauth.rb
@@ -30,6 +30,24 @@ module RedmineOauth
       Setting.plugin_redmine_oauth['self_registration'].to_i
     end
 
+    # Comma-separated domains for self_registration mode 4 (auto-activate if email domain matches).
+    def self_registration_domains_list
+      raw = Setting.plugin_redmine_oauth['self_registration_domains'].to_s
+      raw.split(',').map { |s| s.strip.downcase.delete_prefix('@') }.reject(&:blank?)
+    end
+
+    # True when email's domain exactly matches or is a subdomain of a listed domain.
+    def self_registration_domain_auto_activate?(email)
+      return false if self_registration != 4
+
+      email_domain = email.to_s.downcase.split('@', 2).last
+      return false if email_domain.blank?
+
+      self_registration_domains_list.any? do |d|
+        email_domain == d || email_domain.end_with?(".#{d}")
+      end
+    end
+
     def update_login?
       value = Setting.plugin_redmine_oauth['update_login']
       value.to_i.positive? || value == 'true'


### PR DESCRIPTION
## Summary
Adds a new **Self-registration** mode that automatically activates new OAuth users whose email domain matches an administrator-defined allowlist, and creates everyone else as **pending manual approval** (same behavior as “manual activation by administrator”).
## Motivation
Some deployments want to allow OAuth sign-up for both employees (trusted domains) and external collaborators, without treating every new account as fully active. This mode keeps a single self-registration flow while splitting activation by email domain.
## Behavior
- New option in **Administration → Plugins → Redmine OAuth → Configure**: **“Automatic activation for listed email domains only”** (internal value `4`).
- When selected, an **“Allowed domains (comma-separated)”** field is shown (stored as `self_registration_domains` in plugin settings).
- On first OAuth login, when a new user is created:
  - If the email’s domain **matches** an allowed domain, or is a **subdomain** of one (e.g. `mail.example.com` matches `example.com`) → **`register_automatically`** (same as full automatic activation).
  - Otherwise → **`register_manually_by_administrator`** (same as manual activation).
- Domain parsing: comma-separated, trimmed, case-insensitive, optional leading `@` stripped.
- If the allowlist is empty, no domain matches → new users are created pending admin approval.
## Implementation notes
- `RedmineOauth.self_registration_domains_list` and `RedmineOauth.self_registration_domain_auto_activate?(email)` in `lib/redmine_oauth.rb`.
- `RedmineOauthController#try_to_login` handles `self_registration == 4` by branching between `register_automatically` and `register_manually_by_administrator`.
- Plugin default for `self_registration_domains` is empty in `init.rb`.
- Settings UI: new select option + textarea; `oauth_self_registration_changed()` in `assets/javascripts/redmine_oauth.js` toggles the domains block when mode `4` is selected (also implements the previously referenced handler on the settings page).
- English strings in `config/locales/en.yml` (`oauth_self_registration_by_domain`, `oauth_self_registration_domains`, `oauth_self_registration_domains_info`). Other locales fall back to English unless translated.
## How to test
1. Set **Self-registration** to **Automatic activation for listed email domains only** and set domains e.g. `example.com, partner.org`.
2. Sign in with OAuth using an email `@example.com` (or `@sub.example.com`) → user should be **active** immediately (subject to Redmine’s normal registration flow).
3. Sign in with OAuth using an email on another domain → user should be **registered / pending administrator approval**.
4. Switch to another self-registration mode and confirm the domains field hides and saves correctly.
