### PR TITLE
Fix oauth_provider lookup in imap.rb

### DIFF
--- a/lib/redmine_oauth/imap.rb
+++ b/lib/redmine_oauth/imap.rb
@@ -28,7 +28,7 @@ module RedmineOauth
           scope: imap_options[:scope],
           grant_type: imap_options[:grant_type]
         }
-        oauth_provider = RedmineOauth.find_by(imap: true).first
+        oauth_provider = OauthProvider.find_by(imap: true)
         unless oauth_provider
           Rails.logger.error 'No OAuth provider with IMAP set to On found'
           return


### PR DESCRIPTION
I think the current version code must refer to the old database table format, I've updated and tested this code to work with the new database format.  Before this fix, I was getting an error: undefined method 'find_by' for module RedmineOauth