### PR TITLE
Avoid max_age empty parameter on authorize_url

### DIFF
--- a/app/controllers/redmine_oauth_controller.rb
+++ b/app/controllers/redmine_oauth_controller.rb
@@ -48,75 +48,89 @@ class RedmineOauthController < AccountController
     case oauth_provider.oauth_name
     when 'Azure AD'
       redirect_to RedmineOauth::OauthClient.client(oauth_provider).auth_code.authorize_url(
-        redirect_uri: oauth_callback_url,
-        state: oauth_csrf_token,
-        scope: case oauth_provider.oauth_version
-               when 'v2.0'
-                 'openid profile email'
-               else
-                 'user:email'
-               end,
-        code_challenge: code_challenge,
-        code_challenge_method: 'S256',
-        max_age: params[:reauth] ? 0 : nil
+        {
+          redirect_uri: oauth_callback_url,
+          state: oauth_csrf_token,
+          scope: case oauth_provider.oauth_version
+                 when 'v2.0'
+                   'openid profile email'
+                 else
+                   'user:email'
+                 end,
+          code_challenge: code_challenge,
+          code_challenge_method: 'S256',
+          max_age: params[:reauth] ? 0 : nil
+        }.compact
       )
     when 'GitHub'
       redirect_to RedmineOauth::OauthClient.client(oauth_provider).auth_code.authorize_url(
-        redirect_uri: oauth_callback_url,
-        state: oauth_csrf_token,
-        scope: 'user:email',
-        code_challenge: code_challenge,
-        code_challenge_method: 'S256',
-        max_age: params[:reauth] ? 0 : nil
+        {
+          redirect_uri: oauth_callback_url,
+          state: oauth_csrf_token,
+          scope: 'user:email',
+          code_challenge: code_challenge,
+          code_challenge_method: 'S256',
+          max_age: params[:reauth] ? 0 : nil
+        }.compact
       )
     when 'GitLab'
       url = RedmineOauth::OauthClient.client(oauth_provider).auth_code.authorize_url(
-        redirect_uri: oauth_callback_url,
-        state: oauth_csrf_token,
-        scope: 'read_user',
-        code_challenge: code_challenge,
-        code_challenge_method: 'S256',
-        max_age: params[:reauth] ? 0 : nil
+        {
+          redirect_uri: oauth_callback_url,
+          state: oauth_csrf_token,
+          scope: 'read_user',
+          code_challenge: code_challenge,
+          code_challenge_method: 'S256',
+          max_age: params[:reauth] ? 0 : nil
+        }.compact
       )
       url << "&#{oauth_provider.url_parameters}" if oauth_provider.url_parameters.present?
       redirect_to url
     when 'Google'
       url = RedmineOauth::OauthClient.client(oauth_provider).auth_code.authorize_url(
-        redirect_uri: oauth_callback_url,
-        state: oauth_csrf_token,
-        scope: 'profile email',
-        code_challenge: code_challenge,
-        code_challenge_method: 'S256',
-        max_age: params[:reauth] ? 0 : nil
+        {
+          redirect_uri: oauth_callback_url,
+          state: oauth_csrf_token,
+          scope: 'profile email',
+          code_challenge: code_challenge,
+          code_challenge_method: 'S256',
+          max_age: params[:reauth] ? 0 : nil
+        }.compact
       )
       url << "&#{oauth_provider.url_parameters}" if oauth_provider.url_parameters.present?
       redirect_to url
     when 'Keycloak'
       redirect_to RedmineOauth::OauthClient.client(oauth_provider).auth_code.authorize_url(
-        redirect_uri: oauth_callback_url,
-        state: oauth_csrf_token,
-        scope: 'openid email',
-        code_challenge: code_challenge,
-        code_challenge_method: 'S256',
-        max_age: params[:reauth] ? 0 : nil
+        {
+          redirect_uri: oauth_callback_url,
+          state: oauth_csrf_token,
+          scope: 'openid email',
+          code_challenge: code_challenge,
+          code_challenge_method: 'S256',
+          max_age: params[:reauth] ? 0 : nil
+        }.compact
       )
     when 'Okta'
       redirect_to RedmineOauth::OauthClient.client(oauth_provider).auth_code.authorize_url(
-        redirect_uri: oauth_callback_url,
-        state: oauth_csrf_token,
-        scope: 'openid profile email',
-        code_challenge: code_challenge,
-        code_challenge_method: 'S256',
-        max_age: params[:reauth] ? 0 : nil
+        {
+          redirect_uri: oauth_callback_url,
+          state: oauth_csrf_token,
+          scope: 'openid profile email',
+          code_challenge: code_challenge,
+          code_challenge_method: 'S256',
+          max_age: params[:reauth] ? 0 : nil
+        }.compact
       )
     when 'Custom'
       redirect_to RedmineOauth::OauthClient.client(oauth_provider).auth_code.authorize_url(
-        redirect_uri: oauth_callback_url,
-        state: oauth_csrf_token,
-        scope: oauth_provider.custom_scope,
-        code_challenge: code_challenge,
-        code_challenge_method: 'S256',
-        max_age: params[:reauth] ? 0 : nil
+        {
+          redirect_uri: oauth_callback_url,
+          state: oauth_csrf_token,
+          scope: oauth_provider.custom_scope,
+          code_challenge: code_challenge,
+          code_challenge_method: 'S256',
+          max_age: params[:reauth] ? 0 : nil
+        }.compact
       )
     else
       flash['error'] = l(:oauth_invalid_provider)


### PR DESCRIPTION
I have an issue with the version 4.0.9 that includes the enhancement discussed in #95
There is no problem with the 4.0.8.

I'm using Keycloak, and I'm testing with the `Keycloak` provider as well as with the `Custom` one.

In both cases, the plugin probably reads params[:reauth] == 0, sets the `max_age` to `nil`, which causes an invalid request to Keycloak. In the request URL, I can see a `max_age` parameter without a value:
...code_challenge_method=S256&max_age&scope=...

and Keycloak tries to convert `max_age` to an int, causing an internal error, preventing the login:
```
Invalid request: java.lang.NumberFormatException: For input string: ""
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:xx)
	at java.base/java.lang.Integer.parseInt(Integer.java:xxx)
	at java.base/java.lang.Integer.valueOf(Integer.java:xxx)
	at org.keycloak.protocol.oidc.endpoints.request.AuthzEndpointQueryStringParser.getIntParameter(AuthzEndpointQueryStringParser.java:xx)
```

In the pull request, I'm just compacting the hash used as input for the `authorize_url` function to generally avoid sending null keys.