### PR TITLE
Fix boot crash on Redmine 7.0 / Rails 8: assign model_object instead of using removed DSL

### DIFF
--- a/app/controllers/oauth_providers_controller.rb
+++ b/app/controllers/oauth_providers_controller.rb
@@ -21,7 +21,7 @@
 class OauthProvidersController < ApplicationController
   layout 'admin'
 
-  model_object OauthProvider
+  self.model_object = OauthProvider
   menu_item :oauth_provides
   self.main_menu = false
 


### PR DESCRIPTION
Fixes #133

### Problem

With Redmine 7.0 (Rails 8.1) the app crashes on boot whenever this plugin is installed. In production Rails eager-loads all controllers, `OauthProvidersController` is loaded, and it raises:

```
application_controller.rb:39:in 'model_object': wrong number of arguments (given 1, expected 0) (ArgumentError)
	from app/controllers/oauth_providers_controller.rb:24:in '<class:OauthProvidersController>'
```

Redmine 7.0 removed the class-level `model_object` DSL helper from `ApplicationController` (trunk r24017 / redmine.org #43205, #43230) and migrated its own controllers to assign the `class_attribute` directly (e.g. `self.model_object = Document`). `model_object` is now only the 0-arg reader, so `model_object OauthProvider` raises.

### Fix

```ruby
- model_object OauthProvider
+ self.model_object = OauthProvider
```

`class_attribute :model_object` generates the `model_object=` writer in both Redmine 6.x and 7.x, so this keeps working under the current `requires_redmine 6.0.0`.

### Testing

Redmine 7.0.0 (Rails 8.1.3), Ruby 3.4.8:

- **Before:** the app exits on boot with the `ArgumentError` above and never becomes healthy (restart loop).
- **After:** the app boots normally, and the full Cloudron app lifecycle test passes (51/51), including the OAuth/OIDC login flow that routes through `OauthProvidersController`, plus backup/restore, in-place update, and location change.
